### PR TITLE
Styles

### DIFF
--- a/src/components/Results.css
+++ b/src/components/Results.css
@@ -3,14 +3,13 @@
     flex-direction: column;
     align-items: center;
     min-height: 200px;
-    background-color: var(--light-gray-color);
+    background-color: var(--ultra-light-gray-color);
     border-radius: 5px;
     padding: 4px;
     overflow-x: hidden;
     gap: 10px;
     margin-bottom: 10px;
     padding-bottom: 15px;
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
 
     h2 {
         font-weight: bold;

--- a/src/components/btns/CardBtn.css
+++ b/src/components/btns/CardBtn.css
@@ -7,7 +7,6 @@
     cursor: pointer;
     border-radius: 20px;
     font-weight: 900;
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
     color: var(--primary-color);
     &:hover {
         background-color: var(--primary-color);

--- a/src/components/card/CardSchool.css
+++ b/src/components/card/CardSchool.css
@@ -1,5 +1,4 @@
 .card-school {
-  border: 1px solid var(--gray-color);
   padding: 15px 10px 3px 10px;
   padding-left: 15px;
   background-color: var(--white-color);
@@ -9,7 +8,6 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 8px;
-  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
 
   @media screen and (min-width: 1024px) {
     width: 60%;
@@ -106,6 +104,7 @@
           font-size: 10px;
         }
       }
+
       .km {
         background-color: var(--secondary-color);
         padding: 3px 5px;
@@ -159,11 +158,11 @@
       margin: 0;
       justify-content: center;
 
-        p {
-          margin: 0;
-        }
+      p {
+        margin: 0;
+      }
 
-      img{
+      img {
         width: 20px;
         height: 20px;
       }
@@ -203,7 +202,6 @@
   /* dark theme color overrides */
   @media (prefers-color-scheme: dark) {
     background-color: var(--dark-blue-gray-color);
-    border: 1px solid var(--light-gray-color);
     color: var(--white-color);
 
     .card-school-header {
@@ -211,29 +209,39 @@
         .num {
           background-color: var(--primary-color);
         }
+
         .code,
         .regimen,
         .cra,
         .caes {
           background-color: var(--dark-blue-gray-color);
         }
+
         .code {
-            color: var(--warning-color);
+          color: var(--warning-color);
         }
       }
+
       .distance {
+
         .time,
         .km {
           background-color: var(--primary-color);
+        }
+
+        .car img {
+          filter: brightness(300%);
         }
       }
     }
 
     .card-school-body {
       color: var(--white-color);
+
       .title {
         color: var(--white-color);
       }
+
       .address,
       .phone,
       .schedule,
@@ -243,10 +251,11 @@
 
       div {
         color: var(--white-color);
-        img{
+
+        img {
           filter: brightness(300%);
         }
-      } 
+      }
     }
 
     button {


### PR DESCRIPTION
## Summary

- Remove borders and box shadows from `CardSchool`, `CardBtn`, and the results container for a flatter, cleaner look
- Update results background to use `--ultra-light-gray-color` instead of `--light-gray-color`
- Fix car icon not appearing white in dark mode by applying `filter: brightness(300%)` to `.car img`
- Minor code formatting fixes (indentation, spacing consistency)

## Test plan

- [ ] Verify cards render correctly in light mode (no visible borders or shadows)
- [ ] Verify cards render correctly in dark mode (car icon is white, no regressions on other icons)
- [ ] Check results container background looks correct in both themes
- [ ] Verify card action buttons (`Llamar`, `Mapa`, `Más Info`) render correctly without shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)